### PR TITLE
improve(clean, download): Reduce need to redownload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ task mpsClean {
     dependsOn 'mpsAntClean', 'mpsAntCleanSources'
 }
 
+task clean {
+    dependsOn 'mpsClean'
+}
+
 task mpsTest {
     group 'mps'
     dependsOn 'mpsAntCheck', 'parseTestReportAfterAntCheck'

--- a/gradle/download-mps.gradle
+++ b/gradle/download-mps.gradle
@@ -36,21 +36,23 @@ if (isMac()) {
     targetFolderName = "$outputBundleDirectory/Contents"
 }
 
-task downloadMpsAndPlugins {
+
+task downloadMpsZip {
     group 'mps-download'
     onlyIf {
-        !mpsZipFile.exists() ||
-        mpsPlugins.any { !file("$pluginsDirectory/mps-${getEffectivePluginName(it.key)}.zip").exists() } ||
-        project.hasProperty("customMpsPlugins") && customMpsPlugins.any { !file("$pluginsDirectory/mps-${it.key}.zip").exists() }
+        !mpsZipFile.exists()
     }
     doLast {
-        if (!mpsZipFile.exists()) {
-            mpsZipFile.parentFile.mkdirs()
-            def mpsDownloadLink = "https://download.jetbrains.com/mps/$mpsMajorMinorVersion/MPS-${mpsVersion}.zip"
-            println("downloading $mpsDownloadLink ... (might take few minutes, since it is ca. 400-500 MB)")
-            new URL(mpsDownloadLink).withInputStream { downloadInputStream -> mpsZipFile.withOutputStream { it << downloadInputStream } }
-        }
+        mpsZipFile.parentFile.mkdirs()
+        def mpsDownloadLink = "https://download.jetbrains.com/mps/$mpsMajorMinorVersion/MPS-${mpsVersion}.zip"
+        println("downloading $mpsDownloadLink ... (might take few minutes, since it is ca. 400-500 MB)")
+        new URL(mpsDownloadLink).withInputStream { downloadInputStream -> mpsZipFile.withOutputStream { it << downloadInputStream } }
+    }
+}
 
+task downloadMpsPlugins {
+    // The onlyIf is handeled on a per-plugin basis. Redoing all that logic here would be too much effort.
+    doLast {
         if (!mpsPlugins.isEmpty()) {
             downloadPlugins(pluginsDirectory)
         }
@@ -58,6 +60,11 @@ task downloadMpsAndPlugins {
             downloadCustomPlugins(pluginsDirectory)
         }
     }
+}
+
+task downloadMpsAndPlugins {
+    group 'mps-download'
+    dependsOn downloadMpsZip, downloadMpsPlugins
 }
 
 private def downloadPlugins(def pluginsDirectory) {
@@ -73,7 +80,7 @@ private def downloadPlugins(def pluginsDirectory) {
         def pluginName = getEffectivePluginName(it.key)
         def pluginId = it.value
         def pluginVersion = getEffectivePluginVersion(it.key, mpsVersion)
-        def pluginZipFile = file("$pluginsDirectory/mps-${pluginName}.zip")
+        def pluginZipFile = file("$pluginsDirectory/${getPluginDownloadFileName(pluginName, pluginVersion)}")
         if (!pluginZipFile.exists()) {
             pluginZipFile.parentFile.mkdirs()
             def pluginDownloadLink = obtainDownloadLinkForPlugin(pluginName, pluginId, pluginVersion)
@@ -81,6 +88,10 @@ private def downloadPlugins(def pluginsDirectory) {
             new URL(pluginDownloadLink).withInputStream { downloadInputStream -> pluginZipFile.withOutputStream { it << downloadInputStream } }
         }
     }
+}
+
+private static String getPluginDownloadFileName(String pluginName, String pluginVersion) {
+    return "mps-${pluginName}-${pluginVersion}.zip"
 }
 
 /*
@@ -107,13 +118,17 @@ private static String getEffectivePluginVersion(String configuredPluginName, Str
     return mpsVersion
 }
 
+private static String getCustomPluginDownloadFileName(String pluginName, String pluginLink) {
+    return "mps-${pluginName}-${pluginLink.md5()}.zip"
+}
+
 private def downloadCustomPlugins(def pluginsDirectory) {
     customMpsPlugins.each {
         def pluginName = it.key
-        def pluginZipFile = file("$pluginsDirectory/mps-${pluginName}.zip")
+        def pluginDownloadLink = it.value
+        def pluginZipFile = file("$pluginsDirectory/${getCustomPluginDownloadFileName(pluginName, pluginDownloadLink)}")
         if (!pluginZipFile.exists()) {
             pluginZipFile.parentFile.mkdirs()
-            def pluginDownloadLink = it.value
             println("downloading custom plugin from URL $pluginDownloadLink ... ($pluginName)")
             new URL(pluginDownloadLink).withInputStream { downloadInputStream -> pluginZipFile.withOutputStream { it << downloadInputStream } }
         }
@@ -145,9 +160,21 @@ task buildMpsZipBundle {
 
         def outputDependenciesDirectory = file("$outputBundleDirectory/dependencies")
         copy {
-            fileTree(dir: pluginsDirectory, includes: ['**/*.zip']).each { zipFile ->
-                println("unzipping $zipFile into $targetFolderName/plugins")
-                from zipTree(zipFile)
+            mpsPlugins.each {
+                def pluginName = getEffectivePluginName(it.key)
+                def pluginVersion = getEffectivePluginVersion(it.key, mpsVersion)
+                def pluginZipFile = file("$pluginsDirectory/${getPluginDownloadFileName(pluginName, pluginVersion)}")
+                println("unzipping $pluginZipFile into $targetFolderName/plugins")
+                from zipTree(pluginZipFile)
+            }
+            if (project.hasProperty("customMpsPlugins")) {
+                customMpsPlugins.each {
+                    def pluginName = it.key
+                    def pluginDownloadLink = it.value
+                    def pluginZipFile = file("$pluginsDirectory/${getCustomPluginDownloadFileName(pluginName, pluginDownloadLink)}")
+                    println("unzipping $pluginZipFile into $targetFolderName/plugins")
+                    from zipTree(pluginZipFile)
+                }
             }
             into outputDependenciesDirectory
         }
@@ -321,12 +348,17 @@ task buildOsSpecificBundle {
 
 task cleanMpsBundle(type: Delete) {
     group 'mps-download'
-    delete file("build/download")
     delete file("$outputBundleDirectory")
 }
 
-if (project.tasks.findByName('clean')) {
-    clean.dependsOn cleanMpsBundle
+task cleanMpsDownloads(type: Delete) {
+    group 'mps-download'
+    delete file("build/download")
+}
+
+task cleanMpsBundleAndDownloads(type: Delete) {
+    group 'mps-download'
+    dependsOn cleanMpsBundle, cleanMpsDownloads
 }
 
 task listPlugins {


### PR DESCRIPTION
Allow cleaning mps bundle without cleaning downloads. Allow downloading only exactly what is missing.
Store downloaded plugins with verison to be able to distinguish plugin versions.